### PR TITLE
fixed typos in write.py

### DIFF
--- a/python/modules/alt_splice/write.py
+++ b/python/modules/alt_splice/write.py
@@ -2,7 +2,6 @@ import sys
 import os
 import scipy as sp
 import h5py
-import warnings
 
 def write_events_txt(fn_out_txt, strains, events, fn_counts, event_idx=None, anno_fn=None):
     # write_events_txt(fn_out_txt, strains, events, fn_counts, event_idx, anno_fn)
@@ -308,7 +307,8 @@ def write_events_structured(fn_out_struc, events, idx=None):
             elif ev.event_type == 'mult_exon_skip':
 		if mult_exon_skip_bool:
 		    mult_exon_skip_bool = False
-	            warnings.warn('WARNING: Event type mult_exon_skip not implemented yet for structured output')
+	            print >> sys.stderr, 'WARNING: Event type mult_exon_skip not implemented yet for structured output'
+		break
 		#raise Exception('Event type mult_exon_skip not implemented yet for structured output')
             else:
                 raise Exception("Unknown event type: %s" % ev.event_type)
@@ -340,7 +340,8 @@ def write_events_structured(fn_out_struc, events, idx=None):
             elif ev.event_type == 'mult_exon_skip':
 		if mult_exon_skip_bool:
 		    mult_exon_skip_bool = False
-	            warnings.warn('WARNING: Event type mult_exon_skip not implemented yet for structured output')
+	            print >> sys.stderr, 'WARNING: Event type mult_exon_skip not implemented yet for structured output'
+		break
                 #raise Exception('Event type mult_exon_skip not implemented yet for structured output')
             else:
                 raise Exception("Unknown event type: %s" % ev.event_type)

--- a/python/modules/alt_splice/write.py
+++ b/python/modules/alt_splice/write.py
@@ -2,6 +2,7 @@ import sys
 import os
 import scipy as sp
 import h5py
+import warnings
 
 def write_events_txt(fn_out_txt, strains, events, fn_counts, event_idx=None, anno_fn=None):
     # write_events_txt(fn_out_txt, strains, events, fn_counts, event_idx, anno_fn)
@@ -264,9 +265,10 @@ def write_events_structured(fn_out_struc, events, idx=None):
         idx = sp.arange(events.shape[0])
 
     print 'writing %s events in generic structured format to %s' % (events[0].event_type, fn_out_struc)
+    mult_exon_skip_bool = True
 
     fd_out = open(fn_out_struc, 'w+') 
-
+    
     ### load gene structure
     for i in idx:
 
@@ -304,7 +306,10 @@ def write_events_structured(fn_out_struc, events, idx=None):
                 flanks = '%i^,%i-' % (ev.exons1[0, 1], ev.exons1[-1, 0] + 1) 
                 schain = '%i-%i^,%i-%i^' % (ev.exons1[1, 0] + 1, ev.exons1[1, 1], ev.exons2[1, 0] + 1, ev.exons2[1, 1])
             elif ev.event_type == 'mult_exon_skip':
-                raise Exception('Event type mult_exon_skip not implemented yet for structured output')
+		if mult_exon_skip_bool:
+		    mult_exon_skip_bool = False
+	            warnings.warn('WARNING: Event type mult_exon_skip not implemented yet for structured output')
+		#raise Exception('Event type mult_exon_skip not implemented yet for structured output')
             else:
                 raise Exception("Unknown event type: %s" % ev.event_type)
         ### - strand - revert donor/acceptor
@@ -333,7 +338,10 @@ def write_events_structured(fn_out_struc, events, idx=None):
                 flanks = '%i^,%i-' % (ev.exons1[-1, 0] + 1, ev.exons1[0, 1]) 
                 schain = '%i-%i^,%i-%i^' % (ev.exons1[1, 1], ev.exons1[1, 0] + 1, ev.exons2[1, 1], ev.exons2[1, 0] + 1)
             elif ev.event_type == 'mult_exon_skip':
-                raise Exception('Event type mult_exon_skip not implemented yet for structured output')
+		if mult_exon_skip_bool:
+		    mult_exon_skip_bool = False
+	            warnings.warn('WARNING: Event type mult_exon_skip not implemented yet for structured output')
+                #raise Exception('Event type mult_exon_skip not implemented yet for structured output')
             else:
                 raise Exception("Unknown event type: %s" % ev.event_type)
         print >> fd_out, 'flanks "%s"; structure "%s"; splice_chain "%s";'  % (flanks, struc, schain)

--- a/python/modules/alt_splice/write.py
+++ b/python/modules/alt_splice/write.py
@@ -291,7 +291,7 @@ def write_events_structured(fn_out_struc, events, idx=None):
                     schain = '%i-,%i-' % (min(ev.exons1[-1, 0] + 1, ev.exons2[-1, 0]) + 1, max(ev.exons1[-1, 0], ev.exons2[-1, 0]) + 1)
                 elif sp.all(ev.exons1[-1, :] == ev.exons2[-1, :]):
                     struc = '1^,2^'
-                    flanks = '%i-,%i-' % (max(ev.exons1[0, 0], ev.exons2[0, 0]) + 1, ex.exons1[-1, 0] + 1)
+                    flanks = '%i-,%i-' % (max(ev.exons1[0, 0], ev.exons2[0, 0]) + 1, ev.exons1[-1, 0] + 1)
                     schain = '%i^,%i^' % (min(ev.exons1[0, 1], ev.exons2[0, 1]), max(ev.exons1[0, 1], ev.exons2[0, 1]))
                 else:
                     raise Exception("Misconfigured alt-prime event detected")
@@ -299,7 +299,7 @@ def write_events_structured(fn_out_struc, events, idx=None):
                 struc = '0,1^2-'
                 flanks = '%i-,%i^' % (ev.exons2[0] + 1, ev.exons2[1])
                 schain = ',%i^%i-' % (ev.exons1[0, 1], ev.exons1[1, 0] + 1)
-            elif ev.event_type == 'mutex_exon':
+            elif ev.event_type == 'mutex_exons':
                 struc = '1-2^,3-4^'
                 flanks = '%i^,%i-' % (ev.exons1[0, 1], ev.exons1[-1, 0] + 1) 
                 schain = '%i-%i^,%i-%i^' % (ev.exons1[1, 0] + 1, ev.exons1[1, 1], ev.exons2[1, 0] + 1, ev.exons2[1, 1])
@@ -328,7 +328,7 @@ def write_events_structured(fn_out_struc, events, idx=None):
                 struc = '0,1^2-'
                 flanks = '%i-,%i^' % (ev.exons2[1], ev.exons2[0] + 1)
                 schain = ',%i^%i-' % (ev.exons1[1, 0] + 1, ev.exons1[0, 1])
-            elif ev.event_type == 'mutex_exon':
+            elif ev.event_type == 'mutex_exons':
                 struc = '1-2^,3-4^'
                 flanks = '%i^,%i-' % (ev.exons1[-1, 0] + 1, ev.exons1[0, 1]) 
                 schain = '%i-%i^,%i-%i^' % (ev.exons1[1, 1], ev.exons1[1, 0] + 1, ev.exons2[1, 1], ev.exons2[1, 0] + 1)


### PR DESCRIPTION
Hey Andre,

1) I was running the code, and it crashed while writing output. I discovered that there were a few typos in the write.py function that caused my error, so I fixed them for you.

2) The code also crashed when it attempted to write out information regarding mult_exon_skip events detected in the analysis. I realize that this is not implemented yet, but it appeared that this adversely affected the code from completing the output of the structure for other events. I thus changed the exception to a warning, and added a bit of code to make sure the warning was only printed once (otherwise, the user could get dozens or more messages with the exact same warning).

Cheers,
Warren