### PR TITLE
reverted change to gene count calculation which caused error

### DIFF
--- a/python/spladder_test.py
+++ b/python/spladder_test.py
@@ -170,9 +170,9 @@ def get_gene_expression(CFG, fn_out=None, strain_subset=None):
         else:
             #gene_counts[gidx, :] = sp.dot(IN['segments'][seg_idx, :].T, IN['seg_len'][:][seg_idx]) / sp.sum(IN['seg_len'][:][seg_idx])
             if seg_idx.shape[0] > 1:
-                gene_counts[gidx, :] = sp.dot(IN['segments'][seg_idx, :][:, strain_idx].T, seg_lens[seg_idx]) / CFG['read_length']
+                gene_counts[gidx, :] = sp.dot(IN['segments'][seg_idx, :][:, strain_idx].T, seg_lens[seg_idx, 0]) / CFG['read_length']
             else:
-                gene_counts[gidx, :] = IN['segments'][seg_idx, :][strain_idx] * seg_lens[seg_idx] / CFG['read_length']
+                gene_counts[gidx, :] = IN['segments'][seg_idx, :][strain_idx] * seg_lens[seg_idx, 0] / CFG['read_length']
             #seg_offset += genes[gidx].segmentgraph.seg_edges.shape[0]
 
     IN.close()


### PR DESCRIPTION
Hi Andre,

I was rerunning the spladder_test.py step with the new "non_alt_norm" option, and I got a new error, which stated:
```
Quantifying gene expression ...
[                                                                                                    ] 0 / 46078 (0%) - took 0 sec (ETA: 0 sec)Traceback (most recent call last):
  File "/home/wulab2015linux/warren/Software/spladder_devel/spladder/python/spladder_test.py", line 873, in <module>
    main()
  File "/home/wulab2015linux/warren/Software/spladder_devel/spladder/python/spladder_test.py", line 775, in main
    gene_counts, gene_strains, gene_ids = get_gene_expression(CFG, fn_out=CFG['fname_exp_hdf5'], strain_subset=condition_strains)
  File "/home/wulab2015linux/warren/Software/spladder_devel/spladder/python/spladder_test.py", line 173, in get_gene_expression
    gene_counts[gidx, :] = sp.dot(IN['segments'][seg_idx, :][:, strain_idx].T, seg_lens[seg_idx]) / CFG['read_length']
ValueError: could not broadcast input array from shape (6,1) into shape (6)
```
I pinpointed the error to the changes made in these lines. I'm not sure if the change made here was intentional or accidental, but it didn't work, so I put it back.