### PR TITLE
fix IndexError from write.py line 89

### DIFF
--- a/spladder/alt_splice/write.py
+++ b/spladder/alt_splice/write.py
@@ -78,11 +78,11 @@ def write_events_txt(fn_out_txt, samples, events, fn_counts, event_idx=None, ann
         
         ### new count chunk needed?
         if i >= chunk_idx_event[1]:
-            chunk_idx_event += cs1
+            chunk_idx_event += cs1 * (1 + (i - chunk_idx_event[1]) // cs1)
             event_counts_chunk = IN['event_counts'][:, :, chunk_idx_event[0]:chunk_idx_event[1]]
         ### new psi chunk needed?
         if i >= chunk_idx_psi[1]:
-            chunk_idx_psi += cs2
+            chunk_idx_psi += cs2 * (1 + (i - chunk_idx_psi[1]) // cs2)
             psi_chunk = IN['psi'][:, chunk_idx_psi[0]:chunk_idx_psi[1]]
 
         ev = events[i]


### PR DESCRIPTION
error:

```
Reporting confirmed intron_retention events: writing intron_retention events in gff3 format to AS_output/SRR10900579/spladder/merge_graphs_intron_retention_C3.confirmed.gff3 writing intron_retention events in flat txt format to AS_output/SRR10900579/spladder/merge_graphs_intron_retention_C3.confirmed.txt.gz Traceback (most recent call last): File "/home/circrna/miniconda3/envs/spladder/bin/spladder", line 8, in <module> sys.exit(main()) File "/home/circrna/miniconda3/envs/spladder/lib/python3.8/site-packages/spladder/spladder.py", line 229, in main options.func(options) File "/home/circrna/miniconda3/envs/spladder/lib/python3.8/site-packages/spladder/spladder_build.py", line 163, in spladder analyze_events(event_type, options.bam_fnames, options) File "/home/circrna/miniconda3/envs/spladder/lib/python3.8/site-packages/spladder/alt_splice/analyze.py", line 191, in analyze_events write_events_txt(fn_out_conf_txt, options.samples[sample_idx], events_all, fn_out_count, event_idx=confirmed_idx) File "/home/circrna/miniconda3/envs/spladder/lib/python3.8/site-packages/spladder/alt_splice/write.py", line 89, in write_events_txt counts = event_counts_chunk[:, :, i - chunk_idx_event[0]] IndexError: index 1668 is out of bounds for axis 2 with size 1649
```

I debugged the error and found when the error happened,  `6987 - 5275 > 1055` because the shift size should be added more times of chunk size.

```
1055 cs1

1055 cs2

10

[ 686 1307 1959 2838 3268 3867 4487 6987 6998 8400] event_idx

686

[  0 1055]

1307

[1055 2110]

1959

[1055 2110]

2838

[2110 3165]

3268

[3165 4220]

3867

[3165 4220]

4487

[4220 5275]

6987 i 

[5275 6330] chunk_idx_event
```